### PR TITLE
Fixed Windows infinite loop on "create" commands

### DIFF
--- a/lib/template-base.js
+++ b/lib/template-base.js
@@ -65,13 +65,15 @@ exports.TemplateBase = Object.create(Object.prototype, {
 
     defaultPackageHome: {
         value: function () {
-            var packageHome = process.cwd();
+            var packageHome = process.cwd(),
+                root = qfs.root();
+
             while (true) {
                 if (FS.existsSync(Path.join(packageHome, "package.json"))) {
                     break;
                 }
                 packageHome = Path.resolve(Path.join(packageHome, ".."));
-                if (packageHome === "/") {
+                if (packageHome === root) {
                     packageHome = process.cwd();
                     break;
                 }


### PR DESCRIPTION
Hardcoded "/" root would never be found on Windows, causing an infinite loop.
