### PR TITLE
Add missing command and invalid command error message

### DIFF
--- a/minit
+++ b/minit
@@ -1,4 +1,21 @@
 #!/usr/bin/env node
 
 
-require("./cli").command.parse(process.argv);
+var program = require("./cli").command;
+
+program.parse(process.argv);
+
+if (program.args.length === 0) {
+   program.help();
+} else {
+    var commandNames = program.commands.map(function(command) {
+        return command.name;
+    });
+
+    var commandName = program.args[0];
+    // Consumed command names will be an object.
+    if (typeof commandName === "string" && commandNames.indexOf(commandName) === -1) {
+        console.error("\n  Error: unknown command '" + commandName + "'");
+        program.help();
+    }
+}


### PR DESCRIPTION
When no command is given help is shown by default.
When an invalid command is given an error message is shown followed by the help message.

Commander doesn't support these actions so I had to build our own.
