### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "commander": "~1.1.1",
     "q": "~0.9.6",
-    "q-io": "~1.7",
+    "q-io": "~1.9",
     "npm": "~1.2.18",
     "minidom": "~0.0.2",
     "diacritics": "latest",


### PR DESCRIPTION
Updated q-io dependency to a version that uses copyTree whenever an EXDEV error occurs in move. 
EXDEV is a common error when running minit in FreeBSD (and probably other *nixes) since rename(2) isn't allowed if the link named by "to" and the file named by "from" are on different logical devices (file systems). Which is the case of /tmp.
