### PR TITLE
Return a promise

### DIFF
--- a/lib/create.js
+++ b/lib/create.js
@@ -57,7 +57,8 @@ var create = exports = module.exports = function(templateName, config, templateM
 
     var aTemplate = Template.newWithDirectory(path.join(config.templatesDir,templateName));
 
-    return aTemplate.process(config);
+    return aTemplate.process(config)
+    .thenResolve(config);
 };
 exports.create = create;
 

--- a/test/lib/create-spec.js
+++ b/test/lib/create-spec.js
@@ -2,7 +2,7 @@ var jasmine = require("jasmine-node");
 
 var SandboxedModule = require('sandboxed-module');
 var Command = require("commander").Command;
-
+var Q = require("q");
 var mockFS = require("mocks").fs;
 
 describe("create", function () {
@@ -69,6 +69,42 @@ describe("create", function () {
             expect(testCommand.listeners("create:testTemplate").length).not.toEqual(0);
 
                // .parse([null,null, "create:app"]);
+        });
+
+    });
+    describe("return a promise", function () {
+        var testCommand;
+        beforeEach(function() {
+            testCommand = new Command();
+            testCommand.minitHome = '/minit_home';
+            testCommand.packageHome = '/package_home';
+            testCommand.templatesDir = '/minit_home/templates';
+
+        });
+
+        it("should resolve the component's config details", function() {
+            var create = SandboxedModule.require('../../lib/create', {
+                requires: {
+                    'fs': mocks.simpleFS,
+                    '../templates/testTemplate': mocks.template
+                }
+            });
+            var name = "my-component";
+            return create("testTemplate", {
+                name: name
+            }, {
+                'Template': {
+                    'newWithDirectory': function(config) {
+                        return {
+                            'process': function(config) {
+                                return Q();
+                            }
+                        };
+                    }
+                }
+            }).then(function(results) {
+                expect(results.name).toEqual(name);
+            });
         });
 
     });


### PR DESCRIPTION
Added a test and some code to return promises containing the created components details for caller apps, in case minit normalizes the component name so that it differes from what the caller requested.
