### PR TITLE
Run npm installing a child process

### DIFF
--- a/lib/exec.js
+++ b/lib/exec.js
@@ -1,0 +1,39 @@
+var spawn = require("child_process").spawn;
+var Q = require("q");
+
+/**
+ * Wrap executing a command in a promise
+ * @param  {string} command command to execute
+ * @param  {Array<string>} args    Arguments to the command.
+ * @param  {string} cwd     The working directory to run the command in.
+ * @return {Promise}        A promise for the completion of the command.
+ */
+module.exports = function exec(command, args, cwd) {
+    if (!command || !cwd) {
+        return Q.reject(new Error("Both command and working directory must be given, not " + command + " and " + cwd));
+    }
+    if (args && !args.every(function (arg) {
+        var type = typeof arg;
+        return type === "boolean" || type === "string" || type === "number";
+    })) {
+        return Q.reject(new Error("All arguments must be a boolean, string or number"));
+    }
+
+    var deferred = Q.defer();
+
+    var proc = spawn(command, args, {
+        cwd: cwd,
+        stdio: global.DEBUG ? "inherit" : "ignore"
+    });
+    proc.on("error", function (error) {
+        deferred.reject(new Error(command + " " + args.join(" ") + " in " + cwd + " encountered error " + error.message));
+    });
+    proc.on("exit", function(code) {
+        if (code !== 0) {
+            deferred.reject(new Error(command + " " + args.join(" ") + " in " + cwd + " exited with code " + code));
+        } else {
+            deferred.resolve();
+        }
+    });
+    return deferred.promise;
+};

--- a/templates/package.js
+++ b/templates/package.js
@@ -3,6 +3,7 @@ var path = require('path');
 var fs = require('fs');
 var npm = require("npm");
 var Q = require('q');
+var exec = require('../lib/exec');
 
 exports.Template = Object.create(TemplateBase, {
 
@@ -55,10 +56,16 @@ exports.Template = Object.create(TemplateBase, {
 
     installDependencies: {
         value: function (config) {
-            return Q.ninvoke(npm, "load", (config || null))
-                .then(function (loadedNpm) {
-                    return Q.ninvoke(loadedNpm.commands, "install");
-                });
+
+            var args = ["install"];
+            if (config.production) {
+                args.push("--production");
+            }
+            if (config.production) {
+                args.push("--" + config.loglevel);
+            }
+
+            return exec("npm", args, config.prefix);
         }
     },
 


### PR DESCRIPTION
This completely skirts trying to fix the issue in npm where multiple
calls to load don't yield correctly configured instances of npm for use
through the programmatic API.

i.e. minit create can now be run multiple times in the same process
and correctly install the expected node_modules in each configured
location.

I have hopes that this will be fixed someday in npm so I haven't
completely changed the way we configure npm prior to executing the
command.

The exec promise/subprocess wrapper is provided by @stuk
