### PR TITLE
minit create:app includes test directory.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,5 +3,5 @@ node_modules
 .DS_Store
 build
 junitreport
-test
+test/
 run-test.js


### PR DESCRIPTION
The test directory was getting removed when we package this up for npm because test was in our npmignore file. I've made the pattern more specific, so it only excludes the root-level minit tests but leaves intact all other test directories.
