### PR TITLE
Return the final path of the created result

### DIFF
--- a/lib/create.js
+++ b/lib/create.js
@@ -57,8 +57,13 @@ var create = exports = module.exports = function(templateName, config, templateM
 
     var aTemplate = Template.newWithDirectory(path.join(config.templatesDir,templateName));
 
-    return aTemplate.process(config)
-    .thenResolve(config);
+    return aTemplate.process(config).then(function () {
+        // Build resultPath now that it's known
+        var fileName = config.extensionName ? config.name + "." + config.extensionName : config.name;
+        config.resultPath = path.join(config.packageHome || "", config.destination || "", fileName);
+        return config;
+    });
+
 };
 exports.create = create;
 

--- a/templates/component.js
+++ b/templates/component.js
@@ -46,6 +46,8 @@ exports.Template = Object.create(ModuleTemplate, {
                 options.extendsModuleId = "montage/ui/component";
             }
 
+            options.extensionName = "reel";
+
             ModuleTemplate.didSetOptions.call(this, options);
 
             options.extendsName = this.validateExtendsName(options.extendsName);
@@ -67,7 +69,7 @@ exports.Template = Object.create(ModuleTemplate, {
         value: function() {
             var self = this;
             return ModuleTemplate.finish.apply(self, arguments).then(function(result) {
-                console.log(self.options.name + ".reel created.");
+                console.log(self.options.name + "." + self.options.extensionName + " created.");
                 return result;
             });
         }

--- a/test/lib/create-spec.js
+++ b/test/lib/create-spec.js
@@ -107,5 +107,32 @@ describe("create", function () {
             });
         });
 
+        it("should resolve the path of the result created", function() {
+            var create = SandboxedModule.require('../../lib/create', {
+                requires: {
+                    'fs': mocks.simpleFS,
+                    '../templates/testTemplate': mocks.template
+                }
+            });
+            var name = "my-component";
+            return create("testTemplate", {
+                name: name,
+                destination: "destination/path"
+            }, {
+                'Template': {
+                    'newWithDirectory': function(config) {
+                        return {
+                            'process': function(config) {
+                                config.extensionName = "ext";
+                                return Q();
+                            }
+                        };
+                    }
+                }
+            }).then(function(results) {
+                expect(results.resultPath).toEqual("destination/path/my-component.ext");
+            });
+        });
+
     });
 });


### PR DESCRIPTION
Prior to this it fell to the consumer of minit to build the final path
and the extension was not present anywhere. Now this information is
ferried along in the promise resolution.

It's debatable about what should actually be returned from the creation
API. It feels a little weird adding output into the input config.
