### PR TITLE
Fixed path to Montage logo SVG in app template

### DIFF
--- a/templates/app/__name__/ui/welcome.reel/welcome.html
+++ b/templates/app/__name__/ui/welcome.reel/welcome.html
@@ -26,7 +26,7 @@
 </head>
 <body>
 <div data-montage-id="welcome" data-montage-skin="light" class="Welcome">
-    <h1><img src="assets/images/montage-logo-gradients.svg" alt="Montage"></h1>
+    <h1><img src="../../assets/images/montage-logo-gradients.svg" alt="Montage"></h1>
 
     <p>Welcome to Montage. You are looking at the contents of the Welcome component, located at <kbd>hello/ui/welcome.reel</kbd>. Designed to accompany our <a href="http://montagejs.org/docs/quick-start.html" target="_blank">Quick Start</a> tutorial, this component is but a sample project meant to help kickstart your basic understanding of how to build and architect Montage applications. Step through the tutorial and you will learn how to assemble Montage components into a user interface, surface and synchronize data between objects and the user interface, and listen for and react to events.</p>
 


### PR DESCRIPTION
Montage logo in the welcome reel doesn't appear when testing app generated from template. Steps to reproduce:
1. minit create:app -n Hello
2. cd hello
3. minit serve
