### PR TITLE
Digit global styles

### DIFF
--- a/templates/digit/__name__/assets/style/style.css
+++ b/templates/digit/__name__/assets/style/style.css
@@ -1,9 +1,20 @@
 {{#copyright}}/* {{{copyright}}} */
 
 {{/copyright}}
+
+/**
+ * 1. Prevent iOS text size adjust after orientation change, without disabling
+ *    user zoom.
+ */
+ 
+html {
+    font-family: sans-serif;
+    line-height: 1.3;
+    color: hsl(0,0%,20%);
+    -ms-text-size-adjust: 100%; /* 1 */
+    -webkit-text-size-adjust: 100%; /* 1 */
+}
+
 body {
-    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-    font-size: 13px;
-    line-height: 18px;
-    color: #222;
+    margin: 0;
 }


### PR DESCRIPTION
Some adjustments for the Digit global styles.

Some of the changes:
- Remove `font-size: 13px` which then defaults to `16px`. This is also in anticipation of the sizing change in Digit: https://github.com/montagejs/digit/pull/13
- Set body maring to 0.
- Prevent iOS text size adjust after orientation change
