### PR TITLE
Replace followInsecureSymbolicLinks with followInsecureSymlinks.

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -12,7 +12,7 @@ exports.serve = function(config) {
         .handleHtmlFragmentResponses()
         .listDirectories()
         .directoryIndex()
-        .fileTree(config.root, {followInsecureSymbolicLinks: !!config.insecureSymlinks})
+        .fileTree(config.root, {followInsecureSymlinks: !!config.insecureSymlinks})
         .listen(config.port)
         .then(function (server) {
             console.log("Serving directory at http://localhost:" + server.address().port);


### PR DESCRIPTION
I was using "npm link" inside a montagejs application but symlinks files were not served event with the -i flag.
By replacing followInsecureSymbolicLinks with followInsecureSymlinks, the -i option works.
(at line 55 of node_modules/q-io/http-apps/fs.js the option name is followInsecureSymlinks)
