### PR TITLE
Don't duplicate extensions given as part of name

### DIFF
--- a/lib/create.js
+++ b/lib/create.js
@@ -59,7 +59,19 @@ var create = exports = module.exports = function(templateName, config, templateM
 
     return aTemplate.process(config).then(function () {
         // Build resultPath now that it's known
-        var fileName = config.extensionName ? config.name + "." + config.extensionName : config.name;
+        var extensionName = config.extensionName,
+            fileName = config.name,
+            extensionPattern;
+
+        if (extensionName) {
+            extensionPattern = new RegExp("\." + extensionName + "$");
+
+            // Don't duplicate the extension if it was provided by the client as part of the name
+            if (!extensionPattern.test(fileName)) {
+                fileName = fileName + "." + extensionName;
+            }
+        }
+
         config.resultPath = path.join(config.packageHome || "", config.destination || "", fileName);
         return config;
     });

--- a/templates/module.js
+++ b/templates/module.js
@@ -19,7 +19,7 @@ var _fromDashesToCamel = function(name) {
 exports.Template = Object.create(TemplateBase, {
 
     commandDescription: {
-        value: "component"
+        value: "module"
     },
 
     addOptions: {
@@ -37,6 +37,11 @@ exports.Template = Object.create(TemplateBase, {
 
     didSetOptions: {
         value:function (options) {
+
+            if (!options.extensionName) {
+                options.extensionName = "js";
+            }
+
             if (options.name) {
                 options.name = this.validateName(options.name);
                 var propertyName = _fromDashesToCamel(options.name);

--- a/test/lib/create-spec.js
+++ b/test/lib/create-spec.js
@@ -134,5 +134,59 @@ describe("create", function () {
             });
         });
 
+        it("should not duplicate the extension if provided as part of the specified name", function() {
+            var create = SandboxedModule.require('../../lib/create', {
+                requires: {
+                    'fs': mocks.simpleFS,
+                    '../templates/testTemplate': mocks.template
+                }
+            });
+            var name = "my-component.ext";
+            return create("testTemplate", {
+                name: name,
+                destination: "destination/path"
+            }, {
+                'Template': {
+                    'newWithDirectory': function(config) {
+                        return {
+                            'process': function(config) {
+                                config.extensionName = "ext";
+                                return Q();
+                            }
+                        };
+                    }
+                }
+            }).then(function(results) {
+                    expect(results.resultPath).toEqual("destination/path/my-component.ext");
+                });
+        });
+
+        it("should add the extension to the resulting file", function() {
+            var create = SandboxedModule.require('../../lib/create', {
+                requires: {
+                    'fs': mocks.simpleFS,
+                    '../templates/testTemplate': mocks.template
+                }
+            });
+            var name = "my-component.bar";
+            return create("testTemplate", {
+                name: name,
+                destination: "destination/path"
+            }, {
+                'Template': {
+                    'newWithDirectory': function(config) {
+                        return {
+                            'process': function(config) {
+                                config.extensionName = "ext";
+                                return Q();
+                            }
+                        };
+                    }
+                }
+            }).then(function(results) {
+                    expect(results.resultPath).toEqual("destination/path/my-component.bar.ext");
+                });
+        });
+
     });
 });


### PR DESCRIPTION
It's a pretty typical error and it would be nice to just move along;
I don't think anybody really wants a `foo.js.js` module.
